### PR TITLE
Don't pass whole request to template

### DIFF
--- a/molo/pwa/templates/molo_pwa.html
+++ b/molo/pwa/templates/molo_pwa.html
@@ -7,7 +7,7 @@
 {% for icon in pwa_settings.PWA_ICONS %}
 <link rel="apple-touch-icon" href="{{ icon.src }}" sizes="{{ icon.sizes }}">
 {% endfor %}
-{% if request.user.is_authenticated %}
+{% if user_is_authenticated %}
 <script type="text/javascript">
   var fcmConfig = {
     apiKey: "{{ pwa_settings.PWA_FCM_API_KEY }}",
@@ -21,7 +21,7 @@
     if ('serviceWorker' in navigator) {
         window.addEventListener('load', function () {
             navigator.serviceWorker.register('/serviceworker.js').then(function (registration) {
-              {% if request.user.is_authenticated %}
+              {% if user_is_authenticated %}
                 js = document.createElement('script');
                 js.src = '/fcm.js';
                 js.async = true;

--- a/molo/pwa/templatetags/molo_pwa.py
+++ b/molo/pwa/templatetags/molo_pwa.py
@@ -21,6 +21,6 @@ def molo_pwa_meta(context):
                     for setting_name in dir(app_settings)
                     if setting_name.startswith('PWA_')}
     return {
-        'request': context['request'],
+        'user_is_authenticated': context['request']['user'].is_authenticated,
         'pwa_settings': pwa_settings
     }

--- a/molo/pwa/tests/test_template_tags.py
+++ b/molo/pwa/tests/test_template_tags.py
@@ -1,0 +1,40 @@
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import AnonymousUser
+from django.template import Context, Template
+from django.test import TestCase
+
+from molo.core.tests.base import MoloTestCaseMixin
+
+
+class TemplateTagsTestCase(TestCase, MoloTestCaseMixin):
+    def render_template(self, template_string, context):
+        return Template(template_string).render(Context(context))
+
+    def test_template_renders_without_error(self):
+        template = self.render_template(
+            '{% load molo_pwa %} {% molo_pwa_meta %}',
+            {
+                'request': {'user': AnonymousUser()},
+            },
+        )
+        self.assertIn('<link rel="manifest" href="/manifest.json">', template)
+
+    def test_template_no_fcm_config_if_user_anonymous(self):
+        template = self.render_template(
+            '{% load molo_pwa %} {% molo_pwa_meta %}',
+            {
+                'request': {'user': AnonymousUser()},
+            },
+        )
+        self.assertNotIn('fcmConfig', template)
+
+    def test_template_has_fcm_config_if_user_authed(self):
+        self.mk_main()
+        user = get_user_model().objects.create()
+        template = self.render_template(
+            '{% load molo_pwa %} {% molo_pwa_meta %}',
+            {
+                'request': {'user': user},
+            },
+        )
+        self.assertIn('fcmConfig', template)


### PR DESCRIPTION
We should keep the template as simple as possible and only give it the things it really needs.

I think the test failures are related to https://github.com/praekeltfoundation/molo.pwa/pull/8#issuecomment-365875819.